### PR TITLE
Add an issue template to python-columnclient project

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,11 @@
+### Summary 
+
+### Steps to reproduce the behavior
+
+### Column version
+
+### Operating system / Environment
+
+### Expected behavior
+
+### Actual behavior


### PR DESCRIPTION
This patch adds a template for Issues opened against the
python-columnclient project. That way, minimum information is
present to debug the problem.

Signed-off-by: Eric Brown <browne@vmware.com>