### PR TITLE
Migrate to new PyPI website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build Status](https://travis-ci.org/vmware/python-columnclient.svg?branch=master)](https://travis-ci.org/vmware/python-columnclient)
 [![codecov](https://codecov.io/gh/vmware/python-columnclient/branch/master/graph/badge.svg)](https://codecov.io/gh/vmware/python-columnclient)
-[![Latest Version](https://img.shields.io/pypi/v/columnclient.svg)](https://pypi.python.org/pypi/columnclient/)
-[![Python Versions](https://img.shields.io/pypi/pyversions/columnclient.svg)](https://pypi.python.org/pypi/columnclient/)
-[![Format](https://img.shields.io/pypi/format/columnclient.svg)](https://pypi.python.org/pypi/columnclient/)
+[![Latest Version](https://img.shields.io/pypi/v/columnclient.svg)](https://pypi.org/project/columnclient/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/columnclient.svg)](https://pypi.org/project/columnclient/)
+[![Format](https://img.shields.io/pypi/format/columnclient.svg)](https://pypi.org/project/columnclient/)
 [![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://github.com/vmware/python-columnclient/blob/master/LICENSE)
 
 ## Overview


### PR DESCRIPTION
According to [1], the PyPI website of pypi.python.org has changed
to https://pypi.org. This patch updates all references to the
legacy site.

[1] https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html

Signed-off-by: Eric Brown <browne@vmware.com>