### PR TITLE
Use six module for Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,19 @@ install:
 # command to run tests
 script: tox
 
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=pep8
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: pypy
+      env: TOXENV=pypy
+
 after_success:
   - codecov -e $TRAVIS_PYTHON_VERSION
 

--- a/columnclient/client.py
+++ b/columnclient/client.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-import urlparse
-
 import requests
+from six.moves.urllib import parse
 
 from columnclient import credentials
 from columnclient import runs
@@ -16,7 +15,7 @@ class Client(object):
         protocol = kwargs.get('protocol', 'http')
         netloc = '%s:%d' % (kwargs.get('hostname', '127.0.0.1'),
                             kwargs.get('port', 48620))
-        self.base_url = urlparse.urlunparse((protocol, netloc, '', '', '', ''))
+        self.base_url = parse.urlunparse((protocol, netloc, '', '', '', ''))
         self.credentials = credentials.CredentialsManager(
             self.session, self.base_url)
         self.runs = runs.RunManager(self.session, self.base_url)

--- a/columnclient/credentials.py
+++ b/columnclient/credentials.py
@@ -2,14 +2,15 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import json
-import urlparse
+
+from six.moves.urllib import parse
 
 
 class CredentialsManager(object):
 
     def __init__(self, session, base_url):
         self.session = session
-        self.base_url = urlparse.urljoin(base_url, 'credentials')
+        self.base_url = parse.urljoin(base_url, 'credentials')
 
     def vault_decrypt(self, value):
         creds_url = '{0}?value={1}'.format(self.base_url, value)

--- a/columnclient/runs.py
+++ b/columnclient/runs.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import json
-import urlparse
+
+from six.moves.urllib import parse
 
 
 class Run(object):
@@ -31,7 +32,7 @@ class RunManager(object):
 
     def __init__(self, session, base_url):
         self.session = session
-        self.base_url = urlparse.urljoin(base_url, 'runs')
+        self.base_url = parse.urljoin(base_url, 'runs')
 
     def create(self, playbook_file, **kwargs):
         data = {
@@ -54,7 +55,7 @@ class RunManager(object):
         return Run(self, json.loads(response.text))
 
     def get(self, run):
-        runs_url = urlparse.urljoin(self.base_url + '/', run.id)
+        runs_url = parse.urljoin(self.base_url + '/', run.id)
         response = self.session.get(runs_url)
         return Run(self, json.loads(response.text))
 
@@ -63,5 +64,5 @@ class RunManager(object):
         return [Run(self, run) for run in json.loads(response.text)]
 
     def delete(self, run):
-        runs_url = urlparse.urljoin(self.base_url + '/', run.id)
+        runs_url = parse.urljoin(self.base_url + '/', run.id)
         self.session.delete(runs_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+six

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7'
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 minversion = 1.6
-envlist = pep8,py27
+envlist = pep8,py27,py36
 skipsdist = True
 
 [travis]


### PR DESCRIPTION
Use six module for Python 3 compatibility
    
The urlparse module only exists in Python2, so need to use six to
work with both Python versions.
    
Signed-off-by: Eric Brown <browne@vmware.com>
