### PR TITLE
Remove prerequisites from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,6 @@
 
 ## Try it out
 
-### Prerequisites
-
-* python 2.7
-* requests
-
 ### Install & Run
 
 Install with pip:


### PR DESCRIPTION
Since the requirements.txt already specifies the dependencies, it
doesn't make sense to also have this in the README.

Signed-off-by: Eric Brown <browne@vmware.com>